### PR TITLE
Add helm chart for k8s deploy

### DIFF
--- a/deploy/helm/.helmignore
+++ b/deploy/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+
+name: kubecraft
+description: A minecraft server helm chart that use PaperMC server
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.1.0"
+
+keywords:
+  - minecraft
+  - server
+  - PaperMC

--- a/deploy/helm/templates/configmap/minecraft-bridge.yaml
+++ b/deploy/helm/templates/configmap/minecraft-bridge.yaml
@@ -1,0 +1,6 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: minecraft-bridge-config
+data:
+  MINECRAFT_SERVER_IP: "minecraft-paper.minecraft.svc.cluster.local"

--- a/deploy/helm/templates/configmap/minecraft-gateway.yaml
+++ b/deploy/helm/templates/configmap/minecraft-gateway.yaml
@@ -1,0 +1,7 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: minecraft-gateway-config
+data:
+  MINECRAFT_SERVER_NAMESPACE: "minecraft"
+  MINECRAFT_SERVER_DEPLOYMENT: "minecraft-paper"

--- a/deploy/helm/templates/deployment/bridge.yaml
+++ b/deploy/helm/templates/deployment/bridge.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minecraft-bridge
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {{.Values.podSelector.bridge | toYaml | nindent 6}}
+  template:
+    metadata:
+      labels: {{.Values.podSelector.bridge | toYaml | nindent 8}}
+    spec:
+      containers:
+        - name: minecraft-bridge-container
+          image: "{{ .Values.image.bridge.repository }}:{{ .Values.image.bridge.tag }}"
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: minecraft-bridge-config

--- a/deploy/helm/templates/deployment/gateway.yaml
+++ b/deploy/helm/templates/deployment/gateway.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minecraft-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {{.Values.podSelector.gateway | toYaml | nindent 6}}
+  template:
+    metadata:
+      labels: {{.Values.podSelector.gateway | toYaml | nindent 8}}
+    spec:
+      serviceAccountName: minecraft-api-server
+      containers:
+        - name: minecraft-gateway-container
+          image: "{{ .Values.image.gateway.repository }}:{{ .Values.image.gateway.tag }}"
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: minecraft-gateway-config

--- a/deploy/helm/templates/deployment/minecraft.yaml
+++ b/deploy/helm/templates/deployment/minecraft.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minecraft-paper
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {{.Values.podSelector.minecraft | toYaml | nindent 6}}
+  template:
+    metadata:
+      labels: {{.Values.podSelector.minecraft | toYaml | nindent 8}}
+    spec:
+      containers:
+        - name: minecraft-container
+          image: "birdman0131/minecraft-server:mc21-java21-paper"
+          ports:
+            - containerPort: {{.Values.ports.minecraft}}
+              name: minecraft-tcp
+              protocol: TCP
+          volumeMounts:
+            - name: minecraft-server-volume
+              mountPath: /home/paper/minecraft
+      volumes:
+        - name: minecraft-server-volume
+          persistentVolumeClaim:
+            claimName: minecraft-server-volume-claim

--- a/deploy/helm/templates/rbac/deployment-manager-binding.yaml
+++ b/deploy/helm/templates/rbac/deployment-manager-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: deployment-manager-binding
+  namespace: {{.Release.Namespace}}
+subjects:
+  - kind: ServiceAccount
+    name: minecraft-api-server
+    namespace: {{.Release.Namespace}}
+roleRef:
+  kind: Role
+  name: deployment-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/templates/rbac/deployment-manager.yaml
+++ b/deploy/helm/templates/rbac/deployment-manager.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: deployment-manager
+  namespace: {{.Release.Namespace}}
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "update", "patch"]

--- a/deploy/helm/templates/rbac/service-accounts.yaml
+++ b/deploy/helm/templates/rbac/service-accounts.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: minecraft-api-server
+  namespace: {{ .Release.Namespace }}

--- a/deploy/helm/templates/service/bridge.yaml
+++ b/deploy/helm/templates/service/bridge.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minecraft-bridge
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.ports.bridge }}
+      targetPort: {{ .Values.ports.bridge }}
+      protocol: TCP
+      name: minecraft-bridge-http
+  selector: {{ .Values.podSelector.bridge | toYaml | nindent 4 }}

--- a/deploy/helm/templates/service/gateway.yaml
+++ b/deploy/helm/templates/service/gateway.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubecraft-gateway
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.ports.gateway }}
+      targetPort: {{ .Values.ports.gateway }}
+      protocol: TCP
+      name: minecraft-api-http
+  selector: {{ .Values.podSelector.gateway | toYaml | nindent 4 }}

--- a/deploy/helm/templates/service/minecraft.yaml
+++ b/deploy/helm/templates/service/minecraft.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minecraft-tcp
+spec:
+  type: NodePort
+  #allocateLoadBalancerNodePorts : false
+  ports:
+    - port: {{ .Values.ports.minecraft }}
+      targetPort: {{ .Values.ports.minecraft }}
+      protocol: TCP
+      name: minecraft-tcp
+  selector: {{ .Values.podSelector.minecraft | toYaml | nindent 4 }}

--- a/deploy/helm/templates/volume/local-storage.yaml
+++ b/deploy/helm/templates/volume/local-storage.yaml
@@ -1,0 +1,6 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer

--- a/deploy/helm/templates/volume/pvc.yaml
+++ b/deploy/helm/templates/volume/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minecraft-server-volume-claim
+spec:
+  storageClassName: local-storage
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi

--- a/deploy/helm/templates/volume/volume.yaml
+++ b/deploy/helm/templates/volume/volume.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: minecraft-volume
+  labels:
+    type: local
+spec:
+  storageClassName: local-storage
+  capacity:
+    storage: 100Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain 
+  local:
+    path: /media/bird/D/server/minecraft
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - bird-home-server

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,23 @@
+podSelector:
+  minecraft:
+    app: minecraft-paper
+    tier: server
+  gateway:
+    app: minecraft-gateway
+    tier: backend
+  bridge:
+    app: minecraft-bridge
+    tier: backend
+
+ports:
+  minecraft: 25565
+  gateway: 8000
+  bridge: 8000
+
+image:
+  gateway:
+    repository: kubecraft-gateway
+    tag: latest
+  bridge:
+    repository: minecraft-bridge
+    tag: latest


### PR DESCRIPTION
## Helm chart to deploy the project through gitlab pipeline
- configmap
  - envfile for gateway
  - envfile for bridge
- deployment
  - gateway deployment
  - bridge deployment
  - minecraft server deployment
- rbac
  - service account for gateway
  - deployment-manager role for gateway (allow access the deployments)
  - rolebinding
- service
  - cluster ip for gateway
  - cluster ip for bridge
  - tcp NodePort for minecraft server
- volume
  - persistent volume for minecraft server file