### PR TITLE
feat : update server status determination logic

### DIFF
--- a/deploy/helm/templates/configmap/minecraft-gateway.yaml
+++ b/deploy/helm/templates/configmap/minecraft-gateway.yaml
@@ -5,4 +5,4 @@ metadata:
 data:
   MINECRAFT_SERVER_NAMESPACE: "minecraft"
   MINECRAFT_SERVER_DEPLOYMENT: "minecraft-paper"
-  MINECRAFT_BRIDGE_URL: "http://minecraft-bridge.minecraft.svc.cluster.local:8000"
+  MINECRAFT_BRIDGE_URL: "http://minecraft-bridge.minecraft.svc.cluster.local:9000"

--- a/deploy/helm/templates/rbac/deployment-manager.yaml
+++ b/deploy/helm/templates/rbac/deployment-manager.yaml
@@ -7,3 +7,6 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]

--- a/src/features/kubecraft-gateway/domain/serverstatus.go
+++ b/src/features/kubecraft-gateway/domain/serverstatus.go
@@ -6,6 +6,6 @@ const (
 	Online   ServerStatus = "online"
 	Offline  ServerStatus = "offline"
 	Starting ServerStatus = "starting"
-	Stopping ServerStatus = "pending"
+	Stopping ServerStatus = "stopping"
 	Unknown  ServerStatus = "unknown"
 )

--- a/src/features/kubecraft-gateway/infrastructure/bridgeclient/minecraftbridgeclient.go
+++ b/src/features/kubecraft-gateway/infrastructure/bridgeclient/minecraftbridgeclient.go
@@ -22,8 +22,8 @@ func NewMinecraftBridgeClient(minecraft_bridge_url string) *MinecraftBridgeClien
 
 	return &MinecraftBridgeClient{
 		minecraft_bridge_url: minecraft_bridge_url,
-		ping_endpoint:        minecraft_bridge_url + "api/v1/minecraft/status",
-		status_endpoint:      minecraft_bridge_url + "api/v1/minecraft/ping",
+		ping_endpoint:        minecraft_bridge_url + "api/v1/minecraft/ping",
+		status_endpoint:      minecraft_bridge_url + "api/v1/minecraft/status",
 	}
 }
 

--- a/src/features/kubecraft-gateway/infrastructure/bridgeclient/minecraftbridgeclient.go
+++ b/src/features/kubecraft-gateway/infrastructure/bridgeclient/minecraftbridgeclient.go
@@ -28,31 +28,30 @@ func NewMinecraftBridgeClient(minecraft_bridge_url string) *MinecraftBridgeClien
 }
 
 // Use server replicas and mcstatus to determine server status
-func (c *MinecraftBridgeClient) Ping() (int, error) {
+func (c *MinecraftBridgeClient) Ping() (*float64, error) {
 	resp, err := http.Get(c.ping_endpoint)
 	if err != nil {
-		return -1, fmt.Errorf("failed to make GET request: %w", err)
+		return nil, fmt.Errorf("failed to make GET request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return -1, fmt.Errorf("failed to read response body: %w", err)
+		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
-
 	if resp.StatusCode == http.StatusOK {
 		var pingResp pingResponse
 		err = json.Unmarshal(body, &pingResp)
 		if err != nil {
-			return -1, fmt.Errorf("failed to unmarshal JSON: %w", err)
+			return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
 		}
-		return pingResp.Latency, nil
+		return &pingResp.Latency, nil
 	} else {
 		var errResp errorResponse
 		err = json.Unmarshal(body, &errResp)
 		if err != nil {
-			return -1, fmt.Errorf("failed to unmarshal JSON: %w", err)
+			return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
 		}
-		return -1, &ConnectionError{s: errResp.Error}
+		return nil, &ConnectionError{s: errResp.Error}
 	}
 }

--- a/src/features/kubecraft-gateway/infrastructure/bridgeclient/response.go
+++ b/src/features/kubecraft-gateway/infrastructure/bridgeclient/response.go
@@ -1,7 +1,7 @@
 package bridgeclient
 
 type pingResponse struct {
-	Latency int `json:"latency"`
+	Latency float64 `json:"latency"`
 }
 
 type errorResponse struct {

--- a/src/features/kubecraft-gateway/infrastructure/minekubemonitor.go
+++ b/src/features/kubecraft-gateway/infrastructure/minekubemonitor.go
@@ -12,9 +12,9 @@ type DeploymentWatcher interface {
 
 // MineKubeMonitor implement services.ServerMonitor
 type MineKubeMonitor struct {
-	Config        MinecraftKubeConfig
-	DeployWatcher DeploymentWatcher
-	BridgeClient  bridgeclient.MinecraftBridgeClient
+	Config       MinecraftKubeConfig
+	KubeWatcher  KubeWatcher
+	BridgeClient bridgeclient.MinecraftBridgeClient
 }
 
 // Use server replicas and mcstatus to determine server status

--- a/src/features/kubecraft-gateway/infrastructure/minekubemonitor.go
+++ b/src/features/kubecraft-gateway/infrastructure/minekubemonitor.go
@@ -6,8 +6,9 @@ import (
 	"kubecraft-gateway/infrastructure/bridgeclient"
 )
 
-type DeploymentWatcher interface {
-	GetServerReplicas(deployment string, namespace string) (int32, int32, error)
+type KubeWatcher interface {
+	GetServerReplicas(deployment string, namespace string) (*int32, error)
+	GetServerPodsNumber(namespace string) (*int, error)
 }
 
 // MineKubeMonitor implement services.ServerMonitor
@@ -19,13 +20,18 @@ type MineKubeMonitor struct {
 
 // Use server replicas and mcstatus to determine server status
 func (c *MineKubeMonitor) GetServerStatus() (domain.ServerStatus, error) {
-	targetReplicas, currentReplicas, err := c.DeployWatcher.GetServerReplicas(c.Config.DeploymentName, c.Config.Namespace)
+	replicas, err := c.KubeWatcher.GetServerReplicas(c.Config.DeploymentName, c.Config.Namespace)
 	if err != nil {
 		return domain.Unknown, fmt.Errorf("failed to get minecraft server deployment replicas: %w", err)
 	}
 
-	// * Ping minecraft server to check if server is ready
-	if targetReplicas > 0 {
+	pods, err := c.KubeWatcher.GetServerPodsNumber(c.Config.Namespace)
+	if err != nil {
+		return domain.Unknown, fmt.Errorf("failed to get minecraft server pods: %w", err)
+	}
+
+	if *replicas > 0 {
+		// * Server is started or starting
 		_, err = c.BridgeClient.Ping()
 		if err != nil {
 			_, ok := err.(*bridgeclient.ConnectionError)
@@ -39,8 +45,10 @@ func (c *MineKubeMonitor) GetServerStatus() (domain.ServerStatus, error) {
 			// * Server is ready
 			return domain.Online, nil
 		}
+
 	} else {
-		if currentReplicas == 0 {
+		// * Server is stopped or stopping
+		if *pods == 0 {
 			// * Server is offline
 			return domain.Offline, nil
 		} else {

--- a/src/features/kubecraft-gateway/main.go
+++ b/src/features/kubecraft-gateway/main.go
@@ -92,10 +92,10 @@ func createBridgeClient() (*bridgeclient.MinecraftBridgeClient, error) {
 	}
 }
 
-func createMineKubeMonitor(config infrastructure.MinecraftKubeConfig, bridgeClient bridgeclient.MinecraftBridgeClient, watcher infrastructure.DeploymentWatcher) *infrastructure.MineKubeMonitor {
+func createMineKubeMonitor(config infrastructure.MinecraftKubeConfig, bridgeClient bridgeclient.MinecraftBridgeClient, watcher infrastructure.KubeWatcher) *infrastructure.MineKubeMonitor {
 	return &infrastructure.MineKubeMonitor{
 		Config:        config,
-		DeployWatcher: watcher,
+		KubeWatcher: watcher,
 		BridgeClient:  bridgeClient,
 	}
 }

--- a/src/features/minecraft-bridge/main.py
+++ b/src/features/minecraft-bridge/main.py
@@ -1,5 +1,5 @@
 import os
-from fastapi import APIRouter, FastAPI
+from fastapi import APIRouter, FastAPI, Response, status
 import uvicorn
 from mcstatus import JavaServer
 from dotenv import load_dotenv
@@ -30,18 +30,21 @@ async def api_root():
 
 
 @router.get("/ping", tags=["mcstatus"])
-async def ping():
+async def ping(response: Response):
     try:
         latency = server.ping()
+        response.status_code = status.HTTP_200_OK
         return {"latency": latency}
     except Exception as e:
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         return {"error": str(e)}
 
 
 @router.get("/status", tags=["mcstatus"])
-async def status():
+async def get_status(response: Response):
     try:
         status = server.status()
+        response.status_code = status.HTTP_200_OK
         return {
             "players": {"online": status.players.online, "max": status.players.max},
             "version": status.version.name,
@@ -49,10 +52,11 @@ async def status():
             "icon": status.icon,
         }
     except Exception as e:
+        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         return {"error": str(e)}
 
 
 app.include_router(router)
 
 if __name__ == "__main__":
-    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run("main:app", host="0.0.0.0", port=9000, reload=True)


### PR DESCRIPTION
### Fix bugs
- wrong server status value string
- wrong minecraft-bridge endpoint
- wrong latency data type
### Update server status determination logic
- previous update try to use server deployment.status.replicas as current replicas to determine the sever status
  - but this value doesn't reflect the current state of pods
- new method use pods.list to list all pods with server label to determine server is stopping or stopped
- update helm chart to satify the permission requirements
